### PR TITLE
Correct FM information

### DIFF
--- a/JF-17/JAS-39-C/CoreMods/aircraft/ChinaAssetPack/Entries/Aircrafts/JF-17.lua
+++ b/JF-17/JAS-39-C/CoreMods/aircraft/ChinaAssetPack/Entries/Aircrafts/JF-17.lua
@@ -312,8 +312,8 @@ JF_17 = {
             },
         },
     -------------------------
-    M_empty                    = 6800.0,    -- JF-17 with pilot and nose load, kg
-    M_nominal                  = 9125.0,    -- JF-17 kg (Empty Plus Full Internal Fuel)
+    M_empty                    = 6586.0,    -- JF-17 with pilot and nose load, kg
+    M_nominal                  = 8936.0,    -- JF-17 kg (Empty Plus Full Internal Fuel)
     M_max                      = 14000.0,   -- JF-17 kg (Maximum Take Off Weight)
     M_fuel_max                 = 2325.0,    -- JF-17 kg (Internal Fuel Only)
     H_max                      = 16920,     -- JF-17 m  (Maximum Operational Ceiling)
@@ -366,8 +366,8 @@ JF_17 = {
     wing_type                 = 0,        -- Fixed wing
     flaps_maneuver            = 1.0,        -- Max flaps in take-off and maneuver (0.5 = 1st stage, 1.0 = 2nd stage) (for AI)
 
-    thrust_sum_max            = 12433,        -- JF-17 51.2 kN
-    thrust_sum_ab             = 19569,    -- JF-17 84.6 kN
+    thrust_sum_max            = 11500,        -- JF-17 51.2 kN
+    thrust_sum_ab             = 19000,    -- JF-17 84.6 kN
 
     length                    = 14.1,    -- JF-17 full lenght in m
     height                    = 4.5,        -- JF-17 height in m


### PR DESCRIPTION
Fixed weights for empty, fuel weight, thrust, and AB power to match Gripen.