### PR TITLE
Fix syntax problem preventing spawning aircraft carriers

### DIFF
--- a/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_arm.lua
+++ b/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_arm.lua
@@ -185,7 +185,7 @@ JAS_DWS_39_ARM =
     
     launcher =
     {
-        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, 
+        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, levParam),
         {
             scheme = 
             {

--- a/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_arm.lua
+++ b/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_arm.lua
@@ -327,7 +327,7 @@ JAS_DWS_39_ARM =
             type_name       = _("cluster"),
             cluster_scheme  = "AGM-154B_cluster",
         }
-        )
+        }
     },
 }
 

--- a/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_tv.lua
+++ b/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_tv.lua
@@ -327,7 +327,7 @@ JAS_DWS_39_TV =
             type_name       = _("cluster"),
             cluster_scheme  = "AGM-154B_cluster",
         }
-        )
+        }
     },
 }
 

--- a/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_tv.lua
+++ b/Mods/aircraft/JAS39/Weapons/Loadouts/jas39_dws39_tv.lua
@@ -185,7 +185,7 @@ JAS_DWS_39_TV =
     
     launcher =
     {
-        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, 
+        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, levParam),
         {
             scheme = 
             {


### PR DESCRIPTION
Fix syntax problem which prevents spawning assets such as aircraft carriers in DCS F/A-18c instant action case1 and case3 missions. The fix was mentioned by Urbi in DCS forum thread - cj43g3r a.k.a. searching46dof